### PR TITLE
disable 'stable mode' in Gentoo Prefix bootstrap script, since it's only used for x86_64

### DIFF
--- a/bootstrap-prefix.sh
+++ b/bootstrap-prefix.sh
@@ -2751,7 +2751,7 @@ I can limit your Prefix to use only packages keyworded for stable amd64
 by default.  Of course, you can still enable testing ~amd64 for
 the packages you want, when the need arises.
 EOF
-			[[ ${TODO} == 'noninteractive' ]] && ans=yes ||
+			[[ ${TODO} == 'noninteractive' ]] && ans=no ||
 			read -p "  Do you want to use stable Prefix? [Yn] " ans
 			case "${ans}" in
 				[Yy][Ee][Ss]|[Yy]|"")


### PR DESCRIPTION
cfr. [issue #131](https://github.com/EESSI/compatibility-layer/issues/131)

@bedroge For https://github.com/EESSI/compatibility-layer/pull/126/files