### PR TITLE
also add dev-libs/libgcrypt to package.mask to work around compilation error on ppc64le during Prefix bootstrap

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -22,8 +22,12 @@ prefix_snapshot_version: 20211120
 prefix_user_defined_trusted_dirs:
   - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib"
 prefix_mask_packages: |
-  # Mask glibc >= 2.34, as it's causing issues with the bootstrap, and it's not compatible with CUDA 11.
+  # avoid glibc 2.34, as it's causing issues with the bootstrap, and it's not compatible with CUDA 11.
+  # see https://github.com/EESSI/compatibility-layer/issues/137 + https://bugs.gentoo.org/824482
   >=sys-libs/glibc-2.34
+  # avoid libgcrypt 1.9.4 due to compiler errros on ppc64le,
+  # see https://github.com/EESSI/compatibility-layer/issues/134 + https://bugs.gentoo.org/825722
+  >=dev-libs/libgcrypt-1.9.4
 prefix_use_builtin_bootstrap: no
 prefix_custom_bootstrap_script:
   local: "{{ playbook_dir }}/../../bootstrap-prefix.sh"


### PR DESCRIPTION
@bedroge for https://github.com/EESSI/compatibility-layer/pull/126